### PR TITLE
docs: added stellarmaps to Other tools

### DIFF
--- a/src/static_pages/OtherTools.tsx
+++ b/src/static_pages/OtherTools.tsx
@@ -84,6 +84,16 @@ export default function OtherTools() {
         <List.Item>
           <Anchor
             target="_blank"
+            download=""
+            href="https://github.com/MichaelMakesGames/stellarmaps"
+          >
+            stellarmaps
+          </Anchor>{" "}
+          by MichaelMakesGames, generate stylized maps from Stellaris saves;
+        </List.Item>
+        <List.Item>
+          <Anchor
+            target="_blank"
             href="https://github.com/OldEnt/stellaris-triggers-modifiers-effects-list"
           >
             stellaris-triggers-modifiers-effects-list


### PR DESCRIPTION
This is adding [stellarmaps](https://github.com/MichaelMakesGames/stellarmaps) to the `Other tools` page